### PR TITLE
Update cl_inventory.lua

### DIFF
--- a/gamemode/core/derma/cl_inventory.lua
+++ b/gamemode/core/derma/cl_inventory.lua
@@ -66,6 +66,7 @@ PANEL = {}
 	function PANEL:Init()
 		self:ShowCloseButton(false)
 		self:SetDraggable(true)
+		self:Center()
 		self:MakePopup()
 		self:SetTitle(L"inv")
 


### PR DESCRIPTION
Center inventory. Inventory panel currently appears in the place of the title "Inventory". This fixes that issue.