### PR TITLE
Prevent dupe by synchronizing player's inventory before sell items to vendor

### DIFF
--- a/plugins/vendor/entities/entities/nut_vendor.lua
+++ b/plugins/vendor/entities/entities/nut_vendor.lua
@@ -199,6 +199,7 @@ if (SERVER) then
 		end
 
 		activator.nutVendor = self
+		activator:getChar():getInv():sync(activator, true)
 		netstream.Start(activator, "vendorOpen", self:EntIndex(), unpack(data))
 	end
 

--- a/plugins/vendor/sh_plugin.lua
+++ b/plugins/vendor/sh_plugin.lua
@@ -268,7 +268,7 @@ if (SERVER) then
 
 				local invOkay = true
 				for k, v in pairs(client:getChar():getInv():getItems()) do
-					if (v.uniqueID == uniqueID and v:getID() != 0) then
+					if (v.uniqueID == uniqueID and v:getID() != 0 and istable(nut.item.instances[v:getID()]) and !v:getData("equip", true)) then
 						invOkay = v:remove()
 						found = true
 						name = L(v.name, client)


### PR DESCRIPTION
Players can dupe money from vendor by selling them an item which is not in their inventory