### PR TITLE
Recursively load plugin libraries

### DIFF
--- a/gamemode/core/libs/sh_plugin.lua
+++ b/gamemode/core/libs/sh_plugin.lua
@@ -30,7 +30,7 @@ function nut.plugin.load(uniqueID, path, isSingleFile, variable)
 	nut.util.include(isSingleFile and path or path.."/sh_"..variable:lower()..".lua", "shared")
 	
 	if (!isSingleFile) then
-		nut.util.includeDir(path.."/libs", true)
+		nut.util.includeDir(path.."/libs", true, true)
 		nut.attribs.loadFromDir(path.."/attributes")
 		nut.faction.loadFromDir(path.."/factions")
 		nut.class.loadFromDir(path.."/classes")


### PR DESCRIPTION
This will allow you to have a neater file structure for your schema/plugin libraries. Found myself needing it for loading third party libraries contained in a folder of their own inside the libs folder.