### PR TITLE
Added colors to logs and flag to addRaw

### DIFF
--- a/gamemode/core/libs/sh_log.lua
+++ b/gamemode/core/libs/sh_log.lua
@@ -11,8 +11,8 @@ nut.log.color = {
 	[FLAG_SUCCESS] = Color(50, 200, 50),
 	[FLAG_WARNING] = Color(255, 255, 0),
 	[FLAG_DANGER] = Color(255, 50, 50),
-	[FLAG_SERVER] = Color(200, 200, 220),
-	[FLAG_DEV] = Color(200, 200, 220),
+	[FLAG_SERVER] = Color(120, 0, 255),
+	[FLAG_DEV] = Color(0, 160, 255),
 }
 local consoleColor = Color(50, 200, 50)
 
@@ -50,10 +50,10 @@ if (SERVER) then
 		return text
 	end
 
-	function nut.log.addRaw(logString)		
-		nut.log.send(nut.util.getAdmins(), logString)
+	function nut.log.addRaw(logString, flag)		
+		nut.log.send(nut.util.getAdmins(), logString, flag)
 		
-		Msg("[LOG] ", logString .. "\n")
+		MsgC(consoleColor, "[LOG] ", nut.log.color[flag] or color_white, logString .. "\n")
 		
 		if (!noSave) then
 			file.Append("nutscript/logs/"..os.date("%x"):gsub("/", "-")..".txt", "["..os.date("%X").."]\t"..logString.."\r\n")
@@ -66,7 +66,7 @@ if (SERVER) then
 
 		nut.log.send(nut.util.getAdmins(), logString)
 		
-		Msg("[LOG] ", logString .. "\n")
+		MsgC(consoleColor, "[LOG] ", color_white, logString .. "\n")
 		
 		if (!noSave) then
 			file.Append("nutscript/logs/"..os.date("%x"):gsub("/", "-")..".txt", "["..os.date("%X").."]\t"..logString.."\r\n")
@@ -84,6 +84,6 @@ if (SERVER) then
 	end
 else
 	netstream.Hook("nutLogStream", function(logString, flag)
-		MsgC(consoleColor, "[SERVER] ", color_white, logString .. "\n")
+		MsgC(consoleColor, "[SERVER] ", nut.log.color[flag] or color_white, logString .. "\n")
 	end)
 end


### PR DESCRIPTION
After the previous "Fixing logs" update, colours disappeared and nut.log.add was edited in order to fit with static pre-formatted strings.

My schemas and probably others too, rely on using nut.log.add (now nut.log.addRaw) for messages that are not necessarily connected to a client, but also don't have much advantages of having pre-formated strings with nut.log.addType as they differ from case to case.

In this pull request I'm bringing back the use of colour flags, as they're very useful instead of all text printing out in white colour (not sure why there were removed?) through adding support for flags in nut.log.addRaw(), and also colours in the output for client and server.