### PR TITLE
Fixed plugin load order

### DIFF
--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -24,6 +24,8 @@ timer.Simple(0, function()
         -- Create the SQL tables if they do not exist.
         nut.db.loadTables()
         nut.log.loadTables()
+				
+	hook.Run("OnDatabaseLoaded")
         
         MsgC(Color(0, 255, 0), "NutScript has connected to the database.\n")
         MsgC(Color(0, 255, 0), "Database Type: " .. nut.db.module .. ".\n")

--- a/gamemode/shared.lua
+++ b/gamemode/shared.lua
@@ -61,11 +61,16 @@ nut.item.loadFromDir("nutscript/gamemode/items")
 
 -- Called after the gamemode has loaded.
 function GM:Initialize()
+
+end
+
+-- Called after nut.db.connect callback is ran.
+hook.Add("OnDatabaseLoaded", function()
 	-- Load all of the NutScript plugins.
 	nut.plugin.initialize()
 	-- Restore the configurations from earlier if applicable.
 	nut.config.load()
-end
+end)
 
 ITSTIMETOSTOP = false
 -- Called when a file has been modified.


### PR DESCRIPTION
Plugins now load after the callback supplied to nut.db.connect is called.