### PR TITLE
Adding a "Last Password Used" system.

### DIFF
--- a/plugins/storage/sh_plugin.lua
+++ b/plugins/storage/sh_plugin.lua
@@ -136,10 +136,16 @@ if (SERVER) then
 		local dist = entity:GetPos():Distance(client:GetPos())
 
 		if (dist < 128 and password) then
+			if !client.LastPass then client.LastPass = "" end
 			if (entity.password and entity.password == password) then
 				entity:OpenInv(client)
+				client.LastPass = password
 			else
-				client:notifyLocalized("wrongPassword")
+				if client.LastPass == entity.password then
+					entity:OpenInv(client)
+				else
+					client:notifyLocalized("wrongPassword")
+				end
 			end
 		end
 	end)


### PR DESCRIPTION
When a player enters a working password it saves that to a variable so that when they try to use a crate again,
when it fails to open on a false or wrong password it will check the last password they used that worked.

basically, if you have a billion crates, you can enter the password once and for every crate with that password you can press E then "ok" without entering the password to go in the crate making it marginally better.