### PR TITLE
Add AdvDupe2 compatibility for prop protection.

### DIFF
--- a/plugins/propprotect.lua
+++ b/plugins/propprotect.lua
@@ -65,6 +65,10 @@ if (SERVER) then
 		if ((client.nutNextSpawn or 0) < CurTime()) then
 			client.nutNextSpawn = CurTime() + 0.75
 		else
+			if(client.AdvDupe2 and client.AdvDupe2.Pasting) then
+				return true
+			end
+			
 			return false
 		end
 


### PR DESCRIPTION
Prop protection prevents Advanced Dupe 2 spawns from full creating.