### PR TITLE
Fix not translating Characters tab.

### DIFF
--- a/gamemode/core/derma/cl_character.lua
+++ b/gamemode/core/derma/cl_character.lua
@@ -586,7 +586,7 @@ local PANEL = {}
 vgui.Register("nutCharMenu", PANEL, "EditablePanel")
 
 hook.Add("CreateMenuButtons", "nutCharButton", function(tabs)
-	tabs["Characters"] = function(panel)
+	tabs["characters"] = function(panel)
 		nut.gui.menu:Remove()
 		vgui.Create("nutCharMenu")
 	end


### PR DESCRIPTION
Characters tab presented 'Characters' even player set their language not English.