### PR TITLE
Add hook to allow prevention of character deletion.

### DIFF
--- a/gamemode/core/libs/sh_character.lua
+++ b/gamemode/core/libs/sh_character.lua
@@ -720,6 +720,8 @@ do
 			local isCurrentChar = client:getChar() and client:getChar():getID() == id
 
 			if (character and character.steamID == steamID) then
+				if (hook.Run("CanDeleteChar", client, character)) then return end
+				
 				for k, v in ipairs(client.nutCharList or {}) do
 					if (v == id) then
 						table.remove(client.nutCharList, k)


### PR DESCRIPTION
It doesn't seem that this hook already exists, considering you can just use netstream.Start to call this receiver and it will just do it. Returning inside of PreCharDelete does nothing.