### PR TITLE
Allow prevention of displaying players on the scoreboard.

### DIFF
--- a/gamemode/core/derma/cl_scoreboard.lua
+++ b/gamemode/core/derma/cl_scoreboard.lua
@@ -110,6 +110,11 @@ local PANEL = {}
 		if (!client:getChar() or !IsValid(parent)) then
 			return
 		end
+	
+		local result = hook.Run("CanDisplayPlayer", client)
+		if (result) then
+			return
+		end
 
 		local slot = parent:Add("DPanel")
 		slot:Dock(TOP)


### PR DESCRIPTION
Use hook CanDisplayPlayer, return true when a player should not be displayed.