### PR TITLE
Returning false on CanDisplayPlayer now hides

### DIFF
--- a/gamemode/core/derma/cl_scoreboard.lua
+++ b/gamemode/core/derma/cl_scoreboard.lua
@@ -112,7 +112,7 @@ local PANEL = {}
 		end
 	
 		local result = hook.Run("CanDisplayPlayer", client)
-		if (result) then
+		if (result == false) then
 			return
 		end
 


### PR DESCRIPTION
Inversion of commit #d271ef5, returning false on CanDisplayPlayer now prevents player from being displayed on scoreboard.