### PR TITLE
Move intro to plugin + UI tweaks

### DIFF
--- a/gamemode/core/derma/cl_character.lua
+++ b/gamemode/core/derma/cl_character.lua
@@ -5,17 +5,7 @@ local PANEL = {}
 	function PANEL:Init()
 		local fadeSpeed = 1
 
-		if (IsValid(nut.gui.loading)) then
-			nut.gui.loading:Remove()
-		end
-
-		if (!nut.localData.intro) then
-			timer.Simple(0.1, function()
-				vgui.Create("nutIntro", self)
-			end)
-		else
-			self:playMusic()
-		end
+		self:playMusic()
 
 		if (IsValid(nut.gui.char) or (LocalPlayer().getChar and LocalPlayer():getChar())) then
 			nut.gui.char:Remove()
@@ -35,7 +25,8 @@ local PANEL = {}
 			surface.SetDrawColor(0, 0, 0)
 			surface.DrawRect(0, 0, w, h)
 		end
-		self.darkness:SetZPos(99)
+		self.darkness:SetZPos(-99)
+		self.darkness:SetAlpha(0)
 
 		self.title = self:Add("DLabel")
 		self.title:SetContentAlignment(5)
@@ -47,11 +38,7 @@ local PANEL = {}
 		self.title:SetTextColor(color_white)
 		self.title:SetZPos(100)
 		self.title:SetAlpha(0)
-		self.title:AlphaTo(255, fadeSpeed, 3 * fadeSpeed, function()
-			self.darkness:AlphaTo(0, 2 * fadeSpeed, 0, function()
-				self.darkness:SetZPos(-99)
-			end)
-		end)
+		self.title:AlphaTo(255, fadeSpeed, fadeSpeed)
 		self.title:SetExpensiveShadow(2, Color(0, 0, 0, 200))
 
 		self.subTitle = self:Add("DLabel")
@@ -63,7 +50,7 @@ local PANEL = {}
 		self.subTitle:SizeToContentsY()
 		self.subTitle:SetTextColor(color_white)
 		self.subTitle:SetAlpha(0)
-		self.subTitle:AlphaTo(255, 4 * fadeSpeed, 3 * fadeSpeed)
+		self.subTitle:AlphaTo(255, fadeSpeed, fadeSpeed * 1.25)
 		self.subTitle:SetExpensiveShadow(2, Color(0, 0, 0, 200))
 
 		self.icon = self:Add("DHTML")
@@ -99,7 +86,7 @@ local PANEL = {}
 			label:SetPos(x, y)
 			label:setText(text, noTranslation)
 			label:SetAlpha(0)
-			label:AlphaTo(255, 0.3, (fadeSpeed * 2) + 0.05 * i, function()
+			label:AlphaTo(255, fadeSpeed, (fadeSpeed * 2) + (0.1 * i), function()
 				if (isLast) then
 					fadeSpeed = 0
 				end
@@ -122,6 +109,7 @@ local PANEL = {}
 
 		local function ClearAllButtons(callback)
 			x, y = ScrW() * 0.1, ScrH() * 0.3
+			i = 0
 
 			local i = 1
 			local max = table.Count(self.buttons)
@@ -171,6 +159,7 @@ local PANEL = {}
 
 		function CreateMainButtons()
 			local count = 0
+			i = 0
 
 			for k, v in pairs(nut.faction.teams) do
 				if (nut.faction.hasWhitelist(v.index)) then
@@ -411,7 +400,7 @@ local PANEL = {}
 							local first = true
 
 							self.charList:Clear()
-							self.charList:AlphaTo(255, 0.5, 0.5)
+							self.charList:AlphaTo(255, 0.3)
 
 							for k, v in ipairs(nut.characters) do
 								local character = nut.char.loaded[v]
@@ -585,9 +574,17 @@ local PANEL = {}
 	end
 vgui.Register("nutCharMenu", PANEL, "EditablePanel")
 
+if (IsValid(nut.gui.char)) then
+	vgui.Create("nutCharMenu")
+end
+
 hook.Add("CreateMenuButtons", "nutCharButton", function(tabs)
 	tabs["Characters"] = function(panel)
 		nut.gui.menu:Remove()
 		vgui.Create("nutCharMenu")
 	end
+end)
+
+hook.Add("NutScriptLoaded", "nutCharMenu", function()
+	vgui.Create("nutCharMenu")
 end)

--- a/gamemode/core/hooks/cl_hooks.lua
+++ b/gamemode/core/hooks/cl_hooks.lua
@@ -168,37 +168,6 @@ function GM:LoadFonts(font, genericFont)
 		weight = 800
 	})
 
-	-- Introduction fancy font.
-	font = "Cambria"
-
-	surface.CreateFont("nutIntroTitleFont", {
-		font = font,
-		size = 200,
-		extended = true,
-		weight = 1000
-	})
-
-	surface.CreateFont("nutIntroBigFont", {
-		font = font,
-		size = 48,
-		extended = true,
-		weight = 1000
-	})
-
-	surface.CreateFont("nutIntroMediumFont", {
-		font = font,
-		size = 28,
-		extended = true,
-		weight = 1000
-	})
-
-	surface.CreateFont("nutIntroSmallFont", {
-		font = font,
-		size = 22,
-		extended = true,
-		weight = 1000
-	})
-
 	surface.CreateFont("nutIconsSmall", {
 		font = "fontello",
 		size = 22,
@@ -304,17 +273,6 @@ function GM:CalcViewModelView(weapon, viewModel, oldEyePos, oldEyeAngles, eyePos
 	return vm_origin, vm_angles
 end
 
-function GM:LoadIntro()
-	-- If skip intro is on
-	if (true) then 
-		if (IsValid(nut.gui.char)) then
-			vgui.Create("nutCharMenu")
-		end
-	else
-
-	end
-end
-
 function GM:InitializedConfig()
 	hook.Run("LoadFonts", nut.config.get("font"), nut.config.get("genericFont"))
 
@@ -355,9 +313,34 @@ function GM:InitializedConfig()
 
 		nut.gui.loading = loader
 		nut.config.loaded = true
-
-		hook.Run("LoadIntro")
 	end
+end
+
+function GM:CharacterListLoaded()
+	local hasNotSeenIntro = not nut.localData.intro
+	timer.Create("nutWaitUntilPlayerValid", 0.5, 0, function()
+		if (not IsValid(LocalPlayer())) then return end
+		timer.Remove("nutWaitUntilPlayerValid")
+
+		-- Remove the loading indicator.
+		if (IsValid(nut.gui.loading)) then
+			nut.gui.loading:Remove()
+		end
+
+		-- Show the intro if needed, then show the character menu.
+		local intro =
+			hasNotSeenIntro and hook.Run("CreateIntroduction") or nil
+		if (IsValid(intro)) then
+			intro.nutLoadOldRemove = intro.OnRemove
+			intro.OnRemove = function(panel)
+				panel:nutLoadOldRemove()
+				hook.Run("NutScriptLoaded")
+			end
+			nut.gui.intro = intro
+		else
+			hook.Run("NutScriptLoaded")
+		end
+	end)
 end
 
 function GM:InitPostEntity()

--- a/gamemode/core/libs/character/cl_networking.lua
+++ b/gamemode/core/libs/character/cl_networking.lua
@@ -26,8 +26,13 @@ netstream.Hook("charVar", function(key, value, id)
 end)
 
 netstream.Hook("charMenu", function(data, openNext)
+	local oldCharList = nut.characters
 	if (data) then
 		nut.characters = data
+		if (not oldCharList) then
+			return hook.Run("CharacterListLoaded", data)
+		end
+		hook.Run("CharacterListUpdated", oldCharList, data)
 	end
 
 	OPENNEXT = openNext

--- a/plugins/mapscene.lua
+++ b/plugins/mapscene.lua
@@ -13,8 +13,10 @@ if (CLIENT) then
 
 	function PLUGIN:CalcView(client, origin, angles, fov)
 		local scenes = self.scenes
-
-		if (IsValid(nut.gui.char) and table.Count(scenes) > 0) then
+		local shouldShow = IsValid(nut.gui.char)
+			or not IsValid(LocalPlayer())
+			or not LocalPlayer():getChar()
+		if (shouldShow and table.Count(scenes) > 0) then
 			local key = self.index
 			local value = scenes[self.index]
 

--- a/plugins/nsintro/derma/cl_intro.lua
+++ b/plugins/nsintro/derma/cl_intro.lua
@@ -121,7 +121,7 @@ local PANEL = {}
 
 	function PANEL:OnRemove()
 		if (self.sound) then
-			self.sound:Stop()
+			self.sound:FadeOut(1)
 			self.sound = nil
 
 			if (IsValid(nut.gui.char)) then

--- a/plugins/nsintro/sh_plugin.lua
+++ b/plugins/nsintro/sh_plugin.lua
@@ -2,6 +2,10 @@ PLUGIN.name = "NutScript Intro"
 PLUGIN.author = "Cheesenut"
 PLUGIN.desc = "NutScript and schema introduction shown when players first join."
 
+nut.config.add("introEnabled", true, "Whether or not intro is enabled.", nil, {
+	category = PLUGIN.name
+})
+
 if (CLIENT) then
 	function PLUGIN:LoadFonts()
 		-- Introduction fancy font.
@@ -37,6 +41,8 @@ if (CLIENT) then
 	end
 
 	function PLUGIN:CreateIntroduction()
-		return vgui.Create("nutIntro")
+		if (nut.config.get("introEnabled")) then
+			return vgui.Create("nutIntro")
+		end
 	end
 end

--- a/plugins/nsintro/sh_plugin.lua
+++ b/plugins/nsintro/sh_plugin.lua
@@ -1,0 +1,42 @@
+PLUGIN.name = "NutScript Intro"
+PLUGIN.author = "Cheesenut"
+PLUGIN.desc = "NutScript and schema introduction shown when players first join."
+
+if (CLIENT) then
+	function PLUGIN:LoadFonts()
+		-- Introduction fancy font.
+		local font = "Cambria"
+
+		surface.CreateFont("nutIntroTitleFont", {
+			font = font,
+			size = 200,
+			extended = true,
+			weight = 1000
+		})
+
+		surface.CreateFont("nutIntroBigFont", {
+			font = font,
+			size = 48,
+			extended = true,
+			weight = 1000
+		})
+
+		surface.CreateFont("nutIntroMediumFont", {
+			font = font,
+			size = 28,
+			extended = true,
+			weight = 1000
+		})
+
+		surface.CreateFont("nutIntroSmallFont", {
+			font = font,
+			size = 22,
+			extended = true,
+			weight = 1000
+		})
+	end
+
+	function PLUGIN:CreateIntroduction()
+		return vgui.Create("nutIntro")
+	end
+end


### PR DESCRIPTION
This PR moves the NS introduction into a plugin.

Since the intro was previously tied to the character menu, a new hook is added called `CharacterListLoaded`. This hook is called after all the character list is loaded for the character menu. This hook is then used to call the `NutScriptLoaded` hook, which is ran once the local player entity is valid and other NS data is loaded. The `NutScriptLoaded` then calls the `CreateIntroduction` hook, which returns a panel for the intro. If a panel is returned, the character menu only shows after the panel is removed. Otherwise, if no panel is returned, then the character menu is shown.

The plugin uses the `CreateIntroduction` to create the current intro panel.