### PR TITLE
Save STEAM-name on saveNutData() instead of name

### DIFF
--- a/gamemode/core/libs/sv_player.lua
+++ b/gamemode/core/libs/sv_player.lua
@@ -39,7 +39,7 @@ do
 	end
 
 	function playerMeta:saveNutData()
-		local name = self:Name()
+		local name = self:steamName()
 		local steamID64 = self:SteamID64()
 
 		nut.db.updateTable({


### PR DESCRIPTION
For some reason, the player-table saves character name instead of steamName to data, in contradiction to what's done on line 6 and 27.