### PR TITLE
[1.1-beta] Reintroduce flag colors to nut.log.addRaw

### DIFF
--- a/gamemode/core/libs/sh_log.lua
+++ b/gamemode/core/libs/sh_log.lua
@@ -44,9 +44,9 @@ if (SERVER) then
 		end
 	end
 
-	function nut.log.addRaw(logString, shouldNotify)		
+	function nut.log.addRaw(logString, shouldNotify, flag)		
 		if (shouldNotify) then
-			nut.log.send(nut.util.getAdmins(), logString)
+			nut.log.send(nut.util.getAdmins(), logString, flag)
 		end
 
 		Msg("[LOG] ", logString.."\n")
@@ -76,6 +76,6 @@ if (SERVER) then
 	end
 else
 	netstream.Hook("nutLogStream", function(logString, flag)
-		MsgC(consoleColor, "[SERVER] ", color_white, tostring(logString).."\n")
+		MsgC(consoleColor, "[SERVER] ", nut.log.color[flag] or color_white, tostring(logString).."\n")
 	end)
 end


### PR DESCRIPTION
In the update of NS 1 to 2 the flag-colors disappeared. I put them back in as an option of nut.log.addRaw as it's very useful to separate logs that need extra attention, rather than making everything white.

This is not a breaking change, as if people won't set a flag, it'll fallback to color_white.