### PR TITLE
[1.1-beta] Added global nut.util.dateToNumber(str)

### DIFF
--- a/gamemode/core/sh_util.lua
+++ b/gamemode/core/sh_util.lua
@@ -158,29 +158,17 @@ do
 	ALWAYS_RAISED["nut_poshelper"] = true
 
 	-- Returns how many seconds the player has played on the server in total.
-	local function dateToNumber(str)
-		str = str or os.date("%Y-%m-%d %H:%M:%S", os.time())
-
-		return {
-			year = tonumber(str:sub(1, 4)),
-			month = tonumber(str:sub(6, 7)),
-			day = tonumber(str:sub(9, 10)),
-			hour = tonumber(str:sub(12, 13)),
-			min = tonumber(str:sub(15, 16)),
-			sec = tonumber(str:sub(18, 19)),
-		}
-	end
 
 	if (SERVER) then
 		function playerMeta:getPlayTime()
-			local diff = os.time(dateToNumber(self.lastJoin))
-				- os.time(dateToNumber(self.firstJoin))
+			local diff = os.time(nut.util.dateToNumber(self.lastJoin))
+				- os.time(nut.util.dateToNumber(self.firstJoin))
 			return diff + (RealTime() - (self.nutJoinTime or RealTime()))
 		end
 	else
 		function playerMeta:getPlayTime()
-			local diff = os.time(dateToNumber(nut.lastJoin))
-				- os.time(dateToNumber(nut.firstJoin))
+			local diff = os.time(nut.util.dateToNumber(nut.lastJoin))
+				- os.time(nut.util.dateToNumber(nut.firstJoin))
 			return diff + (RealTime() - nut.joinTime or 0)
 		end
 	end

--- a/gamemode/core/util/sh_time.lua
+++ b/gamemode/core/util/sh_time.lua
@@ -39,3 +39,16 @@ function nut.util.getStringTime(text)
 
 	return time
 end
+
+function nut.util.dateToNumber(str)
+	str = str or os.date("%Y-%m-%d %H:%M:%S", os.time())
+
+	return {
+		year = tonumber(str:sub(1, 4)),
+		month = tonumber(str:sub(6, 7)),
+		day = tonumber(str:sub(9, 10)),
+		hour = tonumber(str:sub(12, 13)),
+		min = tonumber(str:sub(15, 16)),
+		sec = tonumber(str:sub(18, 19)),
+	}
+end


### PR DESCRIPTION
It was local, but since NS started using this ISO-kind of timestamps, it's useful to have this function for everyone who writes plugins and schemas as well.