### PR TITLE
[1.1-beta] Fixed denial of cross-char item-pickup

### DIFF
--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -118,10 +118,13 @@ function GM:CanPlayerInteractItem(client, action, item)
 end
 
 function GM:CanPlayerTakeItem(client, item)
-	if (type(item.entity) == "Entity") then
+	if (IsValid(item.entity)) then
 		local char = client:getChar()
 
-		if (item.entity.nutSteamID and item.entity.nutSteamID == client:SteamID() and item.entity.nutCharID != char:getID()) then
+		if (
+				item.entity.nutSteamID == client:SteamID() and
+				item.entity.nutCharID != char:getID()) 
+			) then
 			client:notifyLocalized("playerCharBelonging")
 
 			return false

--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -110,7 +110,8 @@ function GM:CanPlayerInteractItem(client, action, item)
 		return false
 	end
 
-	if (action == "take" and hook.Run("CanPlayerTakeItem", client, item) == false) then
+	if (action == "take" and hook.Run("
+				Item", client, item) == false) then
 		return false
 	end
 
@@ -123,7 +124,7 @@ function GM:CanPlayerTakeItem(client, item)
 
 		if (
 			item.entity.nutSteamID == client:SteamID() and
-			item.entity.nutCharID ~= char:getID()) 
+			item.entity.nutCharID ~= char:getID()
 		) then
 			client:notifyLocalized("playerCharBelonging")
 

--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -122,9 +122,9 @@ function GM:CanPlayerTakeItem(client, item)
 		local char = client:getChar()
 
 		if (
-				item.entity.nutSteamID == client:SteamID() and
-				item.entity.nutCharID != char:getID()) 
-			) then
+			item.entity.nutSteamID == client:SteamID() and
+			item.entity.nutCharID ~= char:getID()) 
+		) then
 			client:notifyLocalized("playerCharBelonging")
 
 			return false

--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -118,10 +118,10 @@ function GM:CanPlayerInteractItem(client, action, item)
 end
 
 function GM:CanPlayerTakeItem(client, item)
-	if (type(item) == "Entity") then
+	if (type(item.entity) == "Entity") then
 		local char = client:getChar()
 
-		if (item.nutSteamID and item.nutSteamID == client:SteamID() and item.nutCharID != char:getID()) then
+		if (item.entity.nutSteamID and item.entity.nutSteamID == client:SteamID() and item.entity.nutCharID != char:getID()) then
 			client:notifyLocalized("playerCharBelonging")
 
 			return false


### PR DESCRIPTION
This fixes so you can't drop an item on one character, and pick it up with another one.