### PR TITLE
SteamID on join message

### DIFF
--- a/plugins/logging.lua
+++ b/plugins/logging.lua
@@ -22,7 +22,7 @@ if (SERVER) then
 
 	nut.log.addType("playerConnected", function(client, ...)
 		local data = {...}
-		local steamID = data[1]
+		local steamID = data[2]
 
 		return string.format("%s[%s] has connected to the server.", client:Name(), steamID or client:SteamID())
 	end)


### PR DESCRIPTION
It was displaying EntityID-instead.