### PR TITLE
Save the Client IP, not server's

### DIFF
--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -45,7 +45,7 @@ function GM:PlayerInitialSpawn(client)
 	client:loadNutData(function(data)
 		if (!IsValid(client)) then return end
 
-		local address = game.GetIPAddress()
+		local address = client:IPAddress()
 		client:setNutData("lastIP", address)
 
 		netstream.Start(


### PR DESCRIPTION
All my players have my server's IP in lastIP, instead of theirs.. haha. Best to fix that!