### PR TITLE
Create _quantity column for 1.1 compatibility

### DIFF
--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -694,6 +694,9 @@ function GM:NutScriptTablesLoaded()
 		:catch(ignore)
 	nut.db.query("ALTER TABLE nut_players ADD COLUMN _lastJoin DATETIME")
 		:catch(ignore)
+	-- Add missing _quantity column for nut_item table.
+	nut.db.query("ALTER TABLE nut_items ADD COLUMN _quantity INTEGER")
+		:catch(ignore)
 end
 
 function GM:PluginShouldLoad(plugin)


### PR DESCRIPTION
_quantity row in the database was missing from 1.1 servers going into 1.1 beta, as stated in [#281](https://github.com/rebel1324/NutScript/issues/281) and [#291](https://github.com/rebel1324/NutScript/issues/291)