### PR TITLE
Fixed equip in storage after restarts

### DIFF
--- a/plugins/storage/sv_storage.lua
+++ b/plugins/storage/sv_storage.lua
@@ -98,6 +98,7 @@ function PLUGIN:LoadData()
 		nut.inventory.loadByID(invID)
 			:next(function(inventory)
 				if (inventory and IsValid(storage)) then
+					inventory.isStorage = true
 					storage:setInventory(inventory)
 					hook.Run("StorageRestored", storage, inventory)
 				elseif (IsValid(storage)) then


### PR DESCRIPTION
Referring to #273 , this was fixed for storages who just spawned on server, however it would not work if the server was restarted and storage respawned by server. So I fixed it.