### PR TITLE
Fallback to char-skin instead 0 on unwear outfit

### DIFF
--- a/gamemode/items/base/sh_outfit.lua
+++ b/gamemode/items/base/sh_outfit.lua
@@ -56,7 +56,7 @@ function ITEM:removeOutfit(client)
 	character:setModel(character:getData("oldMdl", character:getModel()))
 	character:setData("oldMdl", nil)
 
-	client:SetSkin(character:getData("oldSkin", 0))
+	client:SetSkin(character:getData("oldSkin", character:getData("skin", 0)))
 	character:setData("oldSkin", nil)
 
 	for k, v in pairs(self.bodyGroups or {}) do


### PR DESCRIPTION
If you've citizen models with customs skins, and you wear an outfit that only changes bodygroups - the skin will be reset to 0 when you take off the outfit. This is because it falls back to 0, instead of the skin from the character data.

This is relevant when you make outfits which don't alter the skin of the characters, as then "oldSkin" would be set and used.