### PR TITLE
Draw 3Dtext same way on single-draw as drawing all

### DIFF
--- a/plugins/3dtext.lua
+++ b/plugins/3dtext.lua
@@ -109,16 +109,27 @@ else
 		for k, v in pairs(PLUGIN.list) do
 			-- Generate markup object since it hasn't been done already.
 			local object = nut.markup.parse("<font=nut3D2DFont>"..v[3]:gsub("\\n", "\n"))
+				
+			local pos = {0, 0}
+			local text = {
+					pos = pos,
+					color = color_white,
+					text = "",
+					xalign = 0,
+					yalign = 0,
+					font = ""
+			}
+
 			-- Same thing with adding a shadow.
 			object.onDrawText = function(text, font, x, y, color, alignX, alignY, alpha)
-				draw.TextShadow({
-					pos = {x, y},
-					color = ColorAlpha(color, alpha),
-					text = text,
-					xalign = 0,
-					yalign = alignY,
-					font = font
-				}, 1, alpha)
+				pos[1] = x
+				pos[2] = y
+					
+				text.color = ColorAlpha(color, alpha)
+				text.yalign = alignY
+				text.font = font
+					
+				draw.TextShadow(text, 1, alpha)
 			end
 
 			-- Set the text to have a markup object to draw.

--- a/plugins/3dtext.lua
+++ b/plugins/3dtext.lua
@@ -82,16 +82,14 @@ else
 			local object = nut.markup.parse("<font=nut3D2DFont>"..text:gsub("\\n", "\n"))
 			-- We want to draw a shadow on the text object.
 			object.onDrawText = function(text, font, x, y, color, alignX, alignY, alpha)
-				surface.SetTextPos(x+1, y+1)
-				surface.SetTextColor(0, 0, 0, alpha)
-				surface.SetFont(font)
-				surface.DrawText(text)
-
-				surface.SetTextPos(x, y)
-				surface.SetTextColor(color.r, color.g, color.b, alpha)
-				surface.SetFont(font)
-				surface.DrawText(text)
-				--draw.SimpleTextOutlined(text, font, x, y, ColorAlpha(color, alpha), alignX, alignY, 2, color_black)
+				draw.TextShadow({
+					pos = {x, y},
+					color = ColorAlpha(color, alpha),
+					text = text,
+					xalign = 0,
+					yalign = alignY,
+					font = font
+				}, 1, alpha)
 			end
 
 			-- Add the text to a list of drawn text objects.

--- a/plugins/3dtext.lua
+++ b/plugins/3dtext.lua
@@ -111,7 +111,7 @@ else
 			local object = nut.markup.parse("<font=nut3D2DFont>"..v[3]:gsub("\\n", "\n"))
 				
 			local pos = {0, 0}
-			local text = {
+			local textTable = {
 					pos = pos,
 					color = color_white,
 					text = "",
@@ -125,11 +125,12 @@ else
 				pos[1] = x
 				pos[2] = y
 					
-				text.color = ColorAlpha(color, alpha)
-				text.yalign = alignY
-				text.font = font
+				textTable.color = ColorAlpha(color, alpha)
+				textTable.text = text
+				textTable.yalign = alignY
+				textTable.font = font
 					
-				draw.TextShadow(text, 1, alpha)
+				draw.TextShadow(textTable, 1, alpha)
 			end
 
 			-- Set the text to have a markup object to draw.


### PR DESCRIPTION
There has been a issue where the text doesn't look the exact same when you create it, and when you rejoin and get the list of all texts to render. This is because two different methods were used to draw it, where the first one did not support alignY, making texts appear at the wrong place, but then moving when you reconnected.

I just simple made both functions use the same drawing functions to ensure consistency of the displaying of text.