### PR TITLE
Removal of comparison to invalid variable in removePlayer

### DIFF
--- a/gamemode/core/libs/character/sv_character.lua
+++ b/gamemode/core/libs/character/sv_character.lua
@@ -158,10 +158,11 @@ function nut.char.cleanUpForPlayer(client)
 end
 
 local function removePlayer(client)
-	if (client:getChar() and client:getChar():getID() == id) then
+	if (client:getChar()) then
 		client:KillSilent()
 		client:setNetVar("char", nil)
 		client:Spawn()
+		netstream.Start(client, "charKick", nil, true)
 	end
 end
 


### PR DESCRIPTION
id is nil, and thus when removePlayer is called by nut.char.delete, the player is not kicked back to the menu screen and killed. This leaves them without a character object, but still able to run around and do their thing.

While not much can be gained from doing this, there is one very useful trait from this bug: deleting the active character when a server has starting money configured. It makes it vastly easier to create a script to continuously create, drop money and delete characters rapidly to essentially spawn money. This is what I did on several servers, primarily FroYo Cyberpunk 2099 TOTC and Unity Roleplay Metro 2033 Roleplay.

(Sorry for using you guys as a testbed, rofl)