### PR TITLE
New Hook OnItemLoaded

### DIFF
--- a/gamemode/core/libs/sh_item.lua
+++ b/gamemode/core/libs/sh_item.lua
@@ -20,7 +20,7 @@ function nut.item.load(path, baseID, isBaseItem)
 		uniqueID = (isBaseItem and "base_" or "")..uniqueID
 		local item = nut.item.register(uniqueID, baseID, isBaseItem, path)
 		
-		hook.Run("OnItemLoaded, item)
+		hook.Run("OnItemLoaded", item)
 	elseif (!path:find(".txt")) then
 		ErrorNoHalt(
 			"[NutScript] Item at '"..path.."' follows invalid "..

--- a/gamemode/core/libs/sh_item.lua
+++ b/gamemode/core/libs/sh_item.lua
@@ -18,7 +18,9 @@ function nut.item.load(path, baseID, isBaseItem)
 
 	if (uniqueID) then
 		uniqueID = (isBaseItem and "base_" or "")..uniqueID
-		nut.item.register(uniqueID, baseID, isBaseItem, path)
+		local item = nut.item.register(uniqueID, baseID, isBaseItem, path)
+		
+		hook.Run("OnItemLoaded, item)
 	elseif (!path:find(".txt")) then
 		ErrorNoHalt(
 			"[NutScript] Item at '"..path.."' follows invalid "..


### PR DESCRIPTION
Editing instances of items is difficult, this hook allows for an opportunity to edit items when they are first loaded.