### PR TITLE
Fix colour not resetting once made black

### DIFF
--- a/gamemode/core/derma/cl_spawnicon.lua
+++ b/gamemode/core/derma/cl_spawnicon.lua
@@ -71,6 +71,7 @@ local PANEL = {}
 		else
 			self:SetAmbientLight(Color(20, 20, 20))
 			self:SetAlpha(255)
+			self:SetColor(Color(255, 255, 255))
 
 			for i = 0, 5 do
 				if (i == 1 or i == 5) then


### PR DESCRIPTION
Fixes the issue of if you have someone unrecognised on the scoreboard, but then switch to a character where that player is recognised