### PR TITLE
Divide by clients max health

### DIFF
--- a/plugins/nshud/sh_plugin.lua
+++ b/plugins/nshud/sh_plugin.lua
@@ -71,7 +71,7 @@ function PLUGIN:GetInjuredText(client)
 	local health = client:Health()
 
 	for k, v in pairs(injTextTable) do
-		if ((health / LocalPlayer():GetMaxHealth()) < k) then
+		if ((health / client:GetMaxHealth()) < k) then
 			return v[1], v[2]
 		end
 	end


### PR DESCRIPTION
Issue with if the LocalPlayer has a higher max health than client, it will say the client is injured when in reality, the client is at their max health

The client is networked regardless so might as well divide by the correct value