### PR TITLE
Check against CanPlayerJoinClass

### DIFF
--- a/gamemode/core/libs/sh_class.lua
+++ b/gamemode/core/libs/sh_class.lua
@@ -85,7 +85,9 @@ function nut.class.canBe(client, class)
 		end
 	end
 
-	hook.Run("CanPlayerJoinClass", client, class, info)
+	if (hook.Run("CanPlayerJoinClass", client, class, info) == false) then
+		return false
+	end
 
 	-- See if the class allows the player to join it.
 	return info:onCanBe(client)


### PR DESCRIPTION
So we can deny access to a class via a hook other than having to do it within class files per each class

Will only deny access to class if we return a value of false.

Extremely useful for checking against a mass of classes instead of having to set a check in each class file