### PR TITLE
Chatbox colour fix + schema/plugin load order fix

### DIFF
--- a/gamemode/core/libs/sh_plugin.lua
+++ b/gamemode/core/libs/sh_plugin.lua
@@ -45,7 +45,7 @@ function nut.plugin.load(uniqueID, path, isSingleFile, variable)
 	PLUGIN.loading = true
 	PLUGIN.path = path
 
-	if (!isSingleFile) then
+	if (not isSingleFile) then
 		nut.plugin.loadExtras(path)
 	end
 	nut.util.include(
@@ -145,7 +145,7 @@ function nut.plugin.loadEntities(path)
 			_G[variable] = table.Copy(default)
 				_G[variable].ClassName = v
 
-				if (IncludeFiles(path2, clientOnly) and !client) then
+				if (IncludeFiles(path2, clientOnly) and not client) then
 					if (clientOnly) then
 						if (CLIENT) then
 							register(_G[variable], v)
@@ -200,11 +200,12 @@ end
 
 function nut.plugin.initialize()
 	nut.plugin.loadFromDir(engine.ActiveGamemode().."/preload")
-	nut.plugin.loadFromDir("nutscript/plugins")
-	nut.plugin.loadFromDir(engine.ActiveGamemode().."/plugins")
+
 	nut.plugin.load("schema", engine.ActiveGamemode().."/schema")
 	hook.Run("InitializedSchema")
 
+	nut.plugin.loadFromDir("nutscript/plugins")
+	nut.plugin.loadFromDir(engine.ActiveGamemode().."/plugins")
 	hook.Run("InitializedPlugins")
 	hook.Run("InitializedItems")
 end
@@ -222,7 +223,7 @@ function nut.plugin.loadFromDir(directory)
 end
 
 function nut.plugin.setDisabled(uniqueID, disabled)
-	disabled = util.tobool(disabled)
+	disabled = tobool(disabled)
 
 	local oldData = table.Copy(nut.data.get("unloaded", {}, false, true))
 	oldData[uniqueID] = disabled

--- a/gamemode/core/sh_config.lua
+++ b/gamemode/core/sh_config.lua
@@ -54,6 +54,9 @@ function nut.config.get(key, default)
 
 	if (config) then
 		if (config.value != nil) then
+			if type(config.value) == "table" and config.value.r and config.value.g and config.value.b then -- if the value is a table with rgb values
+				config.value = Color(config.value.r, config.value.g, config.value.b) -- convert it to a Color table
+			end
 			return config.value
 		elseif (config.default != nil) then
 			return config.default
@@ -134,7 +137,6 @@ if (SERVER) then
 					value2 = value2..v..(i == count and "]" or ", ")
 					i = i + 1
 				end
-
 				value = value2
 			end
 
@@ -185,7 +187,7 @@ if (CLIENT) then
 			tabs["config"] = function(panel)
 				local scroll = panel:Add("DScrollPanel")
 				scroll:Dock(FILL)
-				
+
 				hook.Run("CreateConfigPanel", panel)
 
 				local properties = scroll:Add("DProperties")
@@ -223,7 +225,7 @@ if (CLIENT) then
 								value = tonumber(nut.config.get(k)) or value
 							elseif (formType == "boolean") then
 								form = "Boolean"
-								value = util.tobool(nut.config.get(k))
+								value = tobool(nut.config.get(k))
 							else
 								form = "Generic"
 								value = nut.config.get(k) or value
@@ -262,7 +264,7 @@ if (CLIENT) then
 											value = math.Round(value)
 										end
 									elseif (form == "Boolean") then
-										value = util.tobool(value)
+										value = tobool(value)
 									end
 
 									netstream.Start("cfgSet", k, value)

--- a/plugins/chatbox/derma/cl_chatbox.lua
+++ b/plugins/chatbox/derma/cl_chatbox.lua
@@ -1,7 +1,6 @@
 local PANEL = {}
 	local COLOR_FADED = Color(200, 200, 200, 100)
 	local COLOR_ACTIVE = color_white
-	local COLOR_WRONG = Color(255, 100, 80)
 
 	function PANEL:Init()
 		local border = 32
@@ -53,7 +52,7 @@ local PANEL = {}
 						local k2 = "/"..k
 
 						if (k2:match(command)) then
-							local x, y = nut.util.drawText(k2.."  ", 4, i * 20, color)
+							local x = nut.util.drawText(k2.."  ", 4, i * 20, color)
 
 							if (k == command and v.syntax) then
 								local i2 = 0
@@ -121,8 +120,8 @@ local PANEL = {}
 			self.entry = self:Add("EditablePanel")
 			self.entry:SetPos(self.x + 4, self.y + self:GetTall() - 32)
 			self.entry:SetWide(self:GetWide() - 8)
-			self.entry.Paint = function(this, w, h)
-			end
+			--self.entry.Paint = function(this, w, h)
+			--end
 			self.entry.OnRemove = function()
 				hook.Run("FinishChat")
 			end
@@ -259,7 +258,7 @@ local PANEL = {}
 		if (CHAT_CLASS) then
 			text = "<font="..(CHAT_CLASS.font or "nutChatFont")..">"
 		end
-		
+
 		for k, v in ipairs({...}) do
 			if (type(v) == "IMaterial") then
 				local ttx = v:GetName()


### PR DESCRIPTION
Fixes the chatbox color bug that prevents custom chat colours. Was caused by Gmod saving Color tables and normal tables as the same, but treating them differently. Meaning that editing the color table saves it as a normal table, and then fucks up when its trying to be used as a Color table

![unknown](https://user-images.githubusercontent.com/54110479/103529213-eee0d780-4e8d-11eb-8799-741898a58ae5.png)

for some reason plugins loaded BEFORE schema files, where it should be the other way around. This allows plugins to reference schema defined stuff consistently.

(also a few small touches such as removing the deprecated util.tobool with just tobool)