### PR TITLE
Fixing permakill

### DIFF
--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -70,7 +70,7 @@ nut.command.add("flaggive", {
 				local available = ""
 
 				-- Aesthetics~~
-				for k, v in SortedPairs(nut.flag.list) do
+				for k in SortedPairs(nut.flag.list) do
 					if (!target:getChar():hasFlags(k)) then
 						available = available..k
 					end
@@ -221,10 +221,8 @@ nut.command.add("chargiveitem", {
 				end
 			end
 
-			if (arguments[3] and arguments[3] != "") then
-				if (!amount) then
-					return L("invalidArg", client, 3)
-				end
+			if (arguments[3] and arguments[3] ~= "") and (!amount) then
+				return L("invalidArg", client, 3)
 			end
 
 			target:getChar():getInv():add(uniqueID, amount or 1)
@@ -295,6 +293,7 @@ nut.command.add("charunban", {
 			if (nut.util.stringMatches(v:getName(), name)) then
 				if (v:getData("banned")) then
 					v:setData("banned")
+					v:setData("permakilled")
 				else
 					return "@charNotBanned"
 				end
@@ -308,7 +307,6 @@ nut.command.add("charunban", {
 		nut.db.query("SELECT _id, _name, _data FROM nut_characters WHERE _name LIKE \"%"..nut.db.escape(name).."%\" LIMIT 1", function(data)
 			if (data and data[1]) then
 				local charID = tonumber(data[1]._id)
-				local name = data[1]._name
 				local data = util.JSONToTable(data[1]._data or "[]")
 
 				client.nutNextSearch = 0
@@ -318,7 +316,7 @@ nut.command.add("charunban", {
 				end
 
 				data.banned = nil
-				
+
 				nut.db.updateTable({_data = data}, nil, nil, "_id = "..charID)
 				nut.util.notifyLocalized("charUnBan", nil, client:Name(), v:getName())
 			end

--- a/plugins/nsintro/sh_plugin.lua
+++ b/plugins/nsintro/sh_plugin.lua
@@ -11,18 +11,14 @@ nut.config.add("playIntroOnlyOnce", true, "Whether the intro, if enabled, should
 	category = PLUGIN.name
 })
 
-nut.config.add("introFont", "Cambria", "Font of the intro screen", function(_, newFont)
-	if CLIENT then
-		PLUGIN:LoadFonts(newFont)
-	end
-end, {
+nut.config.add("introFont", "Cambria", "Font of the intro screen", nil, {
 	category = PLUGIN.name
 })
 
 if (CLIENT) then
-	function PLUGIN:LoadFonts(newFont)
+	function PLUGIN:LoadFonts()
 		-- Introduction fancy font.
-		local font = newFont or nut.config.get("introFont", "Cambria")
+		local font = nut.config.get("introFont", "Cambria")
 
 		surface.CreateFont("nutIntroTitleFont", {
 			font = font,

--- a/plugins/permakill.lua
+++ b/plugins/permakill.lua
@@ -12,9 +12,8 @@ nut.config.add("pkWorld", false, "Whether or not world and self damage produce p
 
 function PLUGIN:PlayerDeath(client, inflictor, attacker)
 	local character = client:getChar()
-
 	if (nut.config.get("pkActive")) then
-		if !(nut.config.get("pkWorld") and (client == attacker or inflictor:IsWorld())) then
+		if (attacker == client or inflictor:IsWorld()) and not nut.config.get("pkWorld", false) then
 			return
 		end
 		character:setData("permakilled", true)


### PR DESCRIPTION
1: Make the pkWorld code more readable. It works properly now
2: PK'd chars still had the `permakilled` data set to them, even if unbanned. That bans them upon loading the char, which also soft locks the screen as the char isnt loaded but the char select menu is closed. This was fixed

Also minor formatting