### PR TITLE
prevent indexing of inventories that cant be seen

### DIFF
--- a/gamemode/core/meta/sh_item.lua
+++ b/gamemode/core/meta/sh_item.lua
@@ -89,7 +89,7 @@ function ITEM:getOwner()
 	local id = self:getID()
 	for _, v in ipairs(player.GetAll()) do
 		local character = v:getChar()
-		if (character and character:getInv().items[id]) then
+		if (character and character:getInv() and character:getInv().items[id]) then
 			return v
 		end
 	end


### PR DESCRIPTION
getOwner gets called all the time on clients, and attempts to get items of inventories the client doesn't have access privileges.