### PR TITLE
Fix issue with entity loading in specific case

### DIFF
--- a/gamemode/core/libs/sh_plugin.lua
+++ b/gamemode/core/libs/sh_plugin.lua
@@ -113,7 +113,7 @@ function nut.plugin.loadEntities(path)
 	local files, folders
 
 	local function IncludeFiles(path2, clientOnly)
-		if (SERVER and file.Exists(path2.."init.lua", "LUA") or CLIENT) then
+		if ((SERVER and file.Exists(path2.."init.lua", "LUA")) or (CLIENT and file.Exists(path2.."cl_init.lua", "LUA"))) then
 			nut.util.include(
 				path2.."init.lua",
 				clientOnly and "client" or "server"
@@ -125,7 +125,7 @@ function nut.plugin.loadEntities(path)
 
 			return true
 		elseif (file.Exists(path2.."shared.lua", "LUA")) then
-			nut.util.include(path2.."shared.lua")
+			nut.util.include(path2.."shared.lua", "shared")
 
 			return true
 		end


### PR DESCRIPTION
Entities that used folders and only contained shared.lua inside of them do not load. This glitch has probably existed for many years, as this is not a common occurrence.